### PR TITLE
Add md flag for openssl use in macOS 12.3

### DIFF
--- a/EncryptedStrings_Bash.sh
+++ b/EncryptedStrings_Bash.sh
@@ -10,7 +10,7 @@ function GenerateEncryptedString() {
     local STRING="${1}"
     local SALT=$(openssl rand -hex 8)
     local K=$(openssl rand -hex 12)
-    local ENCRYPTED=$(echo "${STRING}" | openssl enc -aes256 -a -A -S "${SALT}" -k "${K}")
+    local ENCRYPTED=$(echo "${STRING}" | openssl enc -aes256 -md md5 -a -A -S "${SALT}" -k "${K}")
     echo "Encrypted String: ${ENCRYPTED}"
     echo "Salt: ${SALT} | Passphrase: ${K}"
 }
@@ -19,7 +19,7 @@ function GenerateEncryptedString() {
 # The 'Salt' and 'Passphrase' values would be present in the script
 function DecryptString() {
     # Usage: ~$ DecryptString "Encrypted String" "Salt" "Passphrase"
-    echo "${1}" | /usr/bin/openssl enc -aes256 -d -a -A -S "${2}" -k "${3}"
+    echo "${1}" | /usr/bin/openssl enc -aes256 -md md5 -d -a -A -S "${2}" -k "${3}"
 }
 
 # Alternative format for DecryptString function
@@ -27,5 +27,5 @@ function DecryptString() {
     # Usage: ~$ DecryptString "Encrypted String"
     local SALT=""
     local K=""
-    echo "${1}" | /usr/bin/openssl enc -aes256 -d -a -A -S "$SALT" -k "$K"
+    echo "${1}" | /usr/bin/openssl enc -aes256 -md md5 -d -a -A -S "$SALT" -k "$K"
 }

--- a/EncryptedStrings_Python.py
+++ b/EncryptedStrings_Python.py
@@ -10,7 +10,7 @@ def GenerateEncryptedString(inputString):
     '''Usage >>> GenerateEncryptedString("String")'''
     salt = subprocess.check_output(['/usr/bin/openssl', 'rand', '-hex', '8']).rstrip()
     passphrase = subprocess.check_output(['/usr/bin/openssl', 'rand', '-hex', '12']).rstrip()
-    p = subprocess.Popen(['/usr/bin/openssl', 'enc', '-aes256', '-md', 'md5', '-md', 'md5', '-a', '-A', '-S', salt, '-k', passphrase], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
+    p = subprocess.Popen(['/usr/bin/openssl', 'enc', '-aes256', '-md', 'md5', '-a', '-A', '-S', salt, '-k', passphrase], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
     encrypted = p.communicate(inputString)[0]
     print("Encrypted String: %s" % encrypted)
     print("Salt: %s | Passphrase: %s" % (salt, passphrase))

--- a/EncryptedStrings_Python.py
+++ b/EncryptedStrings_Python.py
@@ -10,7 +10,7 @@ def GenerateEncryptedString(inputString):
     '''Usage >>> GenerateEncryptedString("String")'''
     salt = subprocess.check_output(['/usr/bin/openssl', 'rand', '-hex', '8']).rstrip()
     passphrase = subprocess.check_output(['/usr/bin/openssl', 'rand', '-hex', '12']).rstrip()
-    p = subprocess.Popen(['/usr/bin/openssl', 'enc', '-aes256', '-a', '-A', '-S', salt, '-k', passphrase], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
+    p = subprocess.Popen(['/usr/bin/openssl', 'enc', '-aes256', '-md', 'md5', '-md', 'md5', '-a', '-A', '-S', salt, '-k', passphrase], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
     encrypted = p.communicate(inputString)[0]
     print("Encrypted String: %s" % encrypted)
     print("Salt: %s | Passphrase: %s" % (salt, passphrase))
@@ -19,7 +19,7 @@ def GenerateEncryptedString(inputString):
 # The 'Salt' and 'Passphrase' values would be present in the script
 def DecryptString(inputString, salt, passphrase):
     '''Usage: >>> DecryptString("Encrypted String", "Salt", "Passphrase")'''
-    p = subprocess.Popen(['/usr/bin/openssl', 'enc', '-aes256', '-d', '-a', '-A', '-S', salt, '-k', passphrase], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
+    p = subprocess.Popen(['/usr/bin/openssl', 'enc', '-aes256', '-md', 'md5', '-d', '-a', '-A', '-S', salt, '-k', passphrase], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
     return p.communicate(inputString)[0]
 
 # Alternative format for DecryptString function
@@ -27,5 +27,5 @@ def DecryptString(inputString):
     '''Usage: >>> DecryptString("Encrypted String")'''
     salt = ""
     passphrase = ""
-    p = subprocess.Popen(['/usr/bin/openssl', 'enc', '-aes256', '-d', '-a', '-A', '-S', salt, '-k', passphrase], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
+    p = subprocess.Popen(['/usr/bin/openssl', 'enc', '-aes256', '-md', 'md5', '-d', '-a', '-A', '-S', salt, '-k', passphrase], stdin = subprocess.PIPE, stdout = subprocess.PIPE)
     return p.communicate(inputString)[0]


### PR DESCRIPTION
Per https://community.jamf.com/t5/jamf-pro/fyi-using-encryptedstrings-method-for-classic-api-calls-requires/td-p/257606